### PR TITLE
Add GitHub Actions workflow for AWS S3 deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Deploy to AWS S3
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Deploy static site to S3 bucket
+        run: |
+          aws s3 sync . s3://${{ secrets.AWS_S3_BUCKET }} \
+            --delete \
+            --exclude ".git/*" \
+            --exclude ".gitignore" \
+            --exclude "README.md" \
+            --exclude ".github/*" \
+            --exclude "*.log" \
+            --exclude ".DS_Store" \
+            --exclude "Thumbs.db"


### PR DESCRIPTION
This workflow triggers on push to the main branch and can be manually dispatched. It configures AWS credentials and deploys the static site to an S3 bucket.